### PR TITLE
fix: make the comment more precise

### DIFF
--- a/java/inheritance/improve-design/src/main/java/it/unibo/inheritance/test/TestBankAccount.java
+++ b/java/inheritance/improve-design/src/main/java/it/unibo/inheritance/test/TestBankAccount.java
@@ -38,7 +38,7 @@ public class TestBankAccount {
         final AccountHolder aRossi = new AccountHolder("Andrea", "Rossi", 1);
         final AccountHolder aBianchi = new AccountHolder("Alex", "Bianchi", 2);
         /*
-         * Change one of the two acounts to ExtendedStrictBankAccount
+         * Change the SimpleBankAccount to ExtendedStrictBankAccount
          */
         final BankAccount rossisAccount = new SimpleBankAccount(aRossi.getUserID(), 0);
         final BankAccount bianchisAccount = new StrictBankAccount(aBianchi.getUserID(), 0);


### PR DESCRIPTION
Since the behavior of `ExtendedStrictBankAccount` should be the same as `StrictBankAccount`, the only way to test it is to replace `SimpleBankAccount` with `ExtendedStrictBankAccount`, otherwise the test still fails.