### PR TITLE
fix: make ExtendedStrictBankAccount consistent with StrictBankAccount implementation

### DIFF
--- a/java/inheritance/improve-design/src/main/java/it/unibo/inheritance/impl/ExtendedStrictBankAccount.java
+++ b/java/inheritance/improve-design/src/main/java/it/unibo/inheritance/impl/ExtendedStrictBankAccount.java
@@ -23,7 +23,7 @@ public class ExtendedStrictBankAccount extends SimpleBankAccount {
     }
 
     protected boolean isWithdrawAllowed(final double amount) {
-        return getBalance() > amount;
+        return getBalance() >= amount;
     }
 
 }


### PR DESCRIPTION
Since the `StrictBankAccount` method `isWithdrawAllowed` is implemented with `balance >= amount`, also for `ExtendedStrictBankAccount` should be the same.